### PR TITLE
optimize wasm with binaryen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .pytest_cache/
 /public/
 /server.bin
+/bin/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,7 +7,12 @@ tasks:
     status:
       - which wasm-opt
     cmds:
-      - apt install binaryen
+      - wget https://github.com/WebAssembly/binaryen/releases/download/version_108/binaryen-version_108-x86_64-linux.tar.gz
+      - tar -xf binaryen-version_108-x86_64-linux.tar.gz
+      - rm binaryen-version_108-x86_64-linux.tar.gz
+      - mv binaryen-version_108/bin/* ~/.local/bin
+      - rm -rf binaryen-version_108
+      - wasm-opt --version
 
   build-frontend:
     env:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -5,14 +5,14 @@ version: "3"
 tasks:
   install-binaryen:
     status:
-      - which wasm-opt
+      - test -f ./bin/wasm-opt
     cmds:
       - wget https://github.com/WebAssembly/binaryen/releases/download/version_108/binaryen-version_108-x86_64-linux.tar.gz
       - tar -xf binaryen-version_108-x86_64-linux.tar.gz
       - rm binaryen-version_108-x86_64-linux.tar.gz
-      - mv binaryen-version_108/bin/* ~/.local/bin
+      - mv binaryen-version_108/bin ./
       - rm -rf binaryen-version_108
-      - wasm-opt --version
+      - ./bin/wasm-opt --version
 
   build-frontend:
     env:
@@ -30,7 +30,7 @@ tasks:
     deps:
       - install-binaryen
     cmds:
-      - wasm-opt -Oz -o public/frontend.wasm public/frontend.wasm
+      - ./bin/wasm-opt -Oz -o public/frontend.wasm public/frontend.wasm
 
   build-server:
     cmds:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -10,7 +10,8 @@ tasks:
       - wget https://github.com/WebAssembly/binaryen/releases/download/version_108/binaryen-version_108-x86_64-linux.tar.gz
       - tar -xf binaryen-version_108-x86_64-linux.tar.gz
       - rm binaryen-version_108-x86_64-linux.tar.gz
-      - mv binaryen-version_108/bin ./
+      - mkdir -p bin
+      - mv binaryen-version_108/bin/* bin/
       - rm -rf binaryen-version_108
       - ./bin/wasm-opt --version
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,8 +1,14 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
 tasks:
+  install-binaryen:
+    status:
+      - which wasm-opt
+    cmds:
+      - sudo apt install binaryen
+
   build-frontend:
     env:
       GOOS: js
@@ -15,6 +21,12 @@ tasks:
       - cp "$GOROOT/misc/wasm/wasm_exec.js" ./public/wasm_exec.js
       - go build -o public/frontend.wasm ./wasm/
 
+  optimize-wasm:
+    deps:
+      - install-binaryen
+    cmds:
+      - wasm-opt -Oz -o public/frontend.wasm public/frontend.wasm
+
   build-server:
     cmds:
       - go build -o server.bin ./server/
@@ -22,8 +34,8 @@ tasks:
   build:
     cmds:
       - task: build-frontend
+      - task: optimize-wasm
       - task: build-server
-
 
   run:
     deps:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,7 +7,7 @@ tasks:
     status:
       - which wasm-opt
     cmds:
-      - sudo apt install binaryen
+      - apt install binaryen
 
   build-frontend:
     env:

--- a/netlify.sh
+++ b/netlify.sh
@@ -4,3 +4,4 @@
 
 sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d
 ./bin/task build-frontend
+./bin/task optimize-wasm


### PR DESCRIPTION
It makes deployment a minute slower but shaves off about 200 kB from the wasm binary. I also tried tinygo, but something doesn't work well with `go:embed`.