### PR TITLE
Basic autocomplete

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -40,7 +40,6 @@ tasks:
   build:
     cmds:
       - task: build-frontend
-      - task: optimize-wasm
       - task: build-server
 
   run:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,8 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js" integrity="sha512-8RnEqURPUc5aqFEN04aQEiPlSAdE0jlFS/9iGgUyNtwFnSKCXhmB6ZTNl7LnDtDWKabJIASzXrzD0K+LYexU9g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css" integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/python/python.min.js" integrity="sha512-2M0GdbU5OxkGYMhakED69bw0c1pW3Nb0PeF3+9d+SnwN1ryPx3wiDdNqK3gSM7KAU/pEV+2tFJFbMKjKAahOkQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/addon/hint/show-hint.min.css" integrity="sha512-OmcLQEy8iGiD7PSm85s06dnR7G7C9C0VqahIPAj/KHk5RpOCmnC6R2ob1oK4/uwYhWa9BF1GC6tzxsC8TIx7Jg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/addon/hint/show-hint.min.js" integrity="sha512-yhmeAerubMLaGAsyS7sE8Oqub6GeTkBDQpkXo2JKHgg7JOCudQvcbDQc5rPxdl7MqcDusTJzSy+ODlyzAwETfQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 
 <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,15 +15,9 @@
   <script src="./wasm_exec.js"></script>
 
   <!-- import web IDE (CodeMirror) -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.min.js"
-    integrity="sha512-WWC1A/JchDFZ2ZGaNyMC7CmPFXGLI/6Ih7WN6YG0DX1NGMkW5lqCVFxCmEx3e56Z7iqdQGpO0f+m2t9CJhdb2Q=="
-    crossorigin="anonymous"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/codemirror.min.css"
-    integrity="sha512-xIf9AdJauwKIVtrVRZ0i4nHP61Ogx9fSRAkCLecmE2dL/U8ioWpDvFCAy4dcfecN72HHB9+7FfQj3aiO68aaaw=="
-    crossorigin="anonymous" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.58.1/mode/python/python.min.js"
-    integrity="sha512-DS+asaww1mE0V/N6YGVgoNIRj+yXB9hAV68vM6rVeWs0G+OyMd24LKrnS4Z+g26rgghU7qvGeEnRVUArV7nVog=="
-    crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.js" integrity="sha512-8RnEqURPUc5aqFEN04aQEiPlSAdE0jlFS/9iGgUyNtwFnSKCXhmB6ZTNl7LnDtDWKabJIASzXrzD0K+LYexU9g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/codemirror.min.css" integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/python/python.min.js" integrity="sha512-2M0GdbU5OxkGYMhakED69bw0c1pW3Nb0PeF3+9d+SnwN1ryPx3wiDdNqK3gSM7KAU/pEV+2tFJFbMKjKAahOkQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 
 <body>

--- a/wasm/autocomplete.go
+++ b/wasm/autocomplete.go
@@ -19,10 +19,15 @@ type AutoComplete struct {
 func (a *AutoComplete) Register() {
 	a.py.Run("import builtins")
 	builtins := strings.Split(a.py.Run("' '.join(dir(builtins))"), " ")
+	a.py.Run("import svg")
+	svg := strings.Split(a.py.Run("' '.join(f'svg.{v}' for v in dir(svg))"), " ")
 
-	globals := make([]any, len(builtins))
-	for i, v := range builtins {
-		globals[i] = v
+	globals := make([]any, 0, len(builtins)+len(svg))
+	for _, v := range builtins {
+		globals = append(globals, v)
+	}
+	for _, v := range svg {
+		globals = append(globals, v)
 	}
 
 	a.window.Get("CodeMirror").Call("registerHelper", "hintWords", "python", globals)

--- a/wasm/autocomplete.go
+++ b/wasm/autocomplete.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"regexp"
+	"strings"
 	"syscall/js"
 
 	"github.com/life4/gweb/web"
@@ -11,9 +12,20 @@ var alpha = regexp.MustCompile(`[a-zA-Z]+`)
 
 type AutoComplete struct {
 	editor web.Value
+	py     Python
+	window web.Window
 }
 
-func (a AutoComplete) Register() {
+func (a *AutoComplete) Register() {
+	a.py.Run("import builtins")
+	builtins := strings.Split(a.py.Run("' '.join(dir(builtins))"), " ")
+
+	globals := make([]any, len(builtins))
+	for i, v := range builtins {
+		globals[i] = v
+	}
+
+	a.window.Get("CodeMirror").Call("registerHelper", "hintWords", "python", globals)
 	a.editor.Call("on", "inputRead", js.FuncOf(a.callback))
 }
 

--- a/wasm/autocomplete.go
+++ b/wasm/autocomplete.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"regexp"
+	"syscall/js"
+
+	"github.com/life4/gweb/web"
+)
+
+var alpha = regexp.MustCompile(`[a-zA-Z]+`)
+
+type AutoComplete struct {
+	editor web.Value
+}
+
+func (a AutoComplete) Register() {
+	a.editor.Call("on", "inputRead", js.FuncOf(a.callback))
+}
+
+func (a AutoComplete) callback(this js.Value, args []js.Value) any {
+	text := args[1].Get("text").Index(0).String()
+	if alpha.MatchString(text) {
+		a.editor.Call("showHint")
+	}
+	return nil
+}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"syscall/js"
+
 	"github.com/life4/gweb/web"
 )
 
@@ -14,12 +16,25 @@ func main() {
 	scripts := NewScripts()
 	ex := scripts.ReadExample()
 	input.SetInnerHTML(ex)
+	window.Get("CodeMirror").Call(
+		"registerHelper", "hintWords", "python",
+		[]any{"abs", "str", "len", "cat", "svg.SVG", "svg.Element"},
+	)
 	editor := window.Get("CodeMirror").Call("fromTextArea",
 		input.JSValue(),
-		map[string]interface{}{
+		map[string]any{
 			"lineNumbers": true,
+			"mode":        "python",
+			"hintOptions": map[string]any{
+				"completeSingle": false,
+			},
 		},
 	)
+	autocomplete := js.FuncOf(func(this js.Value, args []js.Value) any {
+		editor.Call("showHint")
+		return nil
+	})
+	editor.Call("on", "inputRead", autocomplete)
 
 	// load python
 	py := Python{doc: doc, output: doc.Element("py-output")}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"syscall/js"
-
 	"github.com/life4/gweb/web"
 )
 
@@ -30,11 +28,8 @@ func main() {
 			},
 		},
 	)
-	autocomplete := js.FuncOf(func(this js.Value, args []js.Value) any {
-		editor.Call("showHint")
-		return nil
-	})
-	editor.Call("on", "inputRead", autocomplete)
+	ac := AutoComplete{editor: editor}
+	ac.Register()
 
 	// load python
 	py := Python{doc: doc, output: doc.Element("py-output")}

--- a/wasm/main.go
+++ b/wasm/main.go
@@ -14,10 +14,6 @@ func main() {
 	scripts := NewScripts()
 	ex := scripts.ReadExample()
 	input.SetInnerHTML(ex)
-	window.Get("CodeMirror").Call(
-		"registerHelper", "hintWords", "python",
-		[]any{"abs", "str", "len", "cat", "svg.SVG", "svg.Element"},
-	)
 	editor := window.Get("CodeMirror").Call("fromTextArea",
 		input.JSValue(),
 		map[string]any{
@@ -28,8 +24,6 @@ func main() {
 			},
 		},
 	)
-	ac := AutoComplete{editor: editor}
-	ac.Register()
 
 	// load python
 	py := Python{doc: doc, output: doc.Element("py-output")}
@@ -50,6 +44,14 @@ func main() {
 		return
 	}
 	py.Install("svg.py")
+
+	// activate autocomplete
+	ac := AutoComplete{
+		editor: editor,
+		window: window,
+		py:     py,
+	}
+	ac.Register()
 
 	runner := NewRunner(window, doc, editor, &py)
 	runner.Register()


### PR DESCRIPTION
CodeMirror doesn't support autocompletion for Python out of the box, and I'm not smart enough to write a partial parser for Python on JS. I've hacked around a simple autocomplete for words. The only thing that sucks is that after `svg.` it autocompletes everything, including all builtins.

Gosh. If anything feels like diving into autocompletion mechanisms for CodeMirror and writing an autocomplete for Python, that would be great. See https://github.com/codemirror/codemirror5/issues/6348